### PR TITLE
Added bower.json file for bower compatability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "backbone-super",
+  "version": "1.0.0",
+  "homepage": "https://github.com/lukasolson/backbone-super",
+  "authors": [
+    "Lukas Olson <olson.lukas@gmail.com>"
+  ],
+  "description": "A convenient super method for the popular JavaScript library, Backbone.js.",
+  "main": "backbone-super/backbone-super.js",
+  "keywords": [
+    "backbone",
+    "super"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "backbone": "> 0.9"
+  }
+}


### PR DESCRIPTION
Noticed that there was no bower.json file here, yet there is this package registered in the bower registry.  Because of its absence it's causing problems with other libs such as browserify's debrowsery transform; I suspect its causing problems elsewhere, too.  
