### PR TITLE
Minification issue in rails project

### DIFF
--- a/backbone-super/backbone-super.js
+++ b/backbone-super/backbone-super.js
@@ -10,7 +10,7 @@
 	var unImplementedSuper = function(method){throw "Super does not implement this method: " + method;}; 
 
 	var ctor = function(){}, inherits = function(parent, protoProps, staticProps) {
-		var child, _super = parent.prototype, fnTest = /xyz/.test(function(){xyz;}) ? /\b_super\b/ : /.*/;
+		var child, _super = parent.prototype, fnTest = /\b_super\b/;
 
 		// The constructor function for the new subclass is either defined by you
 		// (the "constructor" property in your `extend` definition), or defaulted


### PR DESCRIPTION
When `/xyz/.test(function(){xyz;}) ? /\b_super\b/ : /.*/` gets minified in a rails project (even if we take the already minified version) it will strip the `xyz` from the anonymous function. This causes a javascript error.

The fix is pretty simple. `/xyz/.test(function(){xyz;}) ? /\b_super\b/ : /.*/` always evaluates to `/\b_super\b/`. So `/\b_super\b/` gets always assigned to `fnTest`.
