### PR TITLE
Issue #28 - Added main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "A convenient super method for the popular JavaScript library, Backbone.js.",
   "author": "Lukas Olson <olson.lukas@gmail.com>",
+  "main": "./backbone-super/backbone-super.js",
   "jam": {
     "include": [
       "backbone-super/backbone-super.js",


### PR DESCRIPTION
After adding this property main and referencing the library we can
now use this script in nodejs or with browserify.

From npm's documentation:

The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module's exports object will be returned.

This should be a module ID relative to the root of your package folder.

For most modules, it makes the most sense to have a main script and often not much else.

- Fix: Added main to package.json