### PR TITLE
Make fnTest not match _super in line comments

### DIFF
--- a/backbone-super/backbone-super.js
+++ b/backbone-super/backbone-super.js
@@ -30,7 +30,7 @@
 	};
 	var unImplementedSuper = function(method){throw "Super does not implement this method: " + method;};
 
-  var fnTest = /\b_super\b/;
+  var fnTest = /((?!\/\/).)*?\b_super\b/m;
 
   var makeWrapper = function(parentProto, name, fn) {
     var wrapper = function() {


### PR DESCRIPTION
Multiline comments are much harder to distinguish with a regex. This is probably an indication that the current method of testing wether super is used in a method is not very good. Maybe another method needs to be found.
